### PR TITLE
Correct the name of Jo Daviess County, Illinois.

### DIFF
--- a/src/epub/text/endnotes.xhtml
+++ b/src/epub/text/endnotes.xhtml
@@ -135,7 +135,7 @@
 					<p>General John <abbr class="name">G.</abbr> Foster <a href="chapter-45.xhtml#noteref-20" epub:type="se:referrer">↩</a></p>
 				</li>
 				<li id="note-21" epub:type="rearnote">
-					<p>During this winter the citizens of Jo Davies County, Ill., subscribed for and had a diamond-hilted sword made for General Grant, which was always known as the Chattanooga sword. The scabbard was of gold, and was ornamented with a scroll running nearly its entire length, displaying in engraved letters the names of the battles in which General Grant had participated.</p>
+					<p>During this winter the citizens of Jo Daviess County, Ill., subscribed for and had a diamond-hilted sword made for General Grant, which was always known as the Chattanooga sword. The scabbard was of gold, and was ornamented with a scroll running nearly its entire length, displaying in engraved letters the names of the battles in which General Grant had participated.</p>
 					<p>Congress also gave him a vote of thanks for the victories at Chattanooga, and voted him a gold medal for Vicksburg and Chattanooga. All such things are now in the possession of the government at Washington. <a href="chapter-45.xhtml#noteref-21" epub:type="se:referrer">↩</a></p>
 				</li>
 				<li id="note-22" epub:type="rearnote">


### PR DESCRIPTION
This error is present in the original scan, but it is clearly an error.

(Fun fact, the county name itself is misspelled, as it was named after Jo Dav**ei**ss. But that’s something to take up with the government of Illinois…)